### PR TITLE
LOD properties Retrieval

### DIFF
--- a/orange_cb_recsys/content_analyzer/config.py
+++ b/orange_cb_recsys/content_analyzer/config.py
@@ -4,6 +4,7 @@ from typing import List, Dict, Set
 from orange_cb_recsys.content_analyzer.field_content_production_techniques.field_content_production_technique import \
     FieldContentProductionTechnique, CollectionBasedTechnique
 from orange_cb_recsys.content_analyzer.information_processor.information_processor import InformationProcessor
+from orange_cb_recsys.content_analyzer.lod_properties_retrieval import LODPropertiesRetrieval
 from orange_cb_recsys.content_analyzer.memory_interfaces.memory_interfaces import InformationInterface
 from orange_cb_recsys.content_analyzer.raw_information_source import RawInformationSource
 
@@ -129,7 +130,8 @@ class ContentAnalyzerConfig:
                  id_field_name,
                  output_directory: str,
                  search_index=False,
-                 field_config_dict: Dict[str, FieldConfig] = None):
+                 field_config_dict: Dict[str, FieldConfig] = None,
+                 lod_properties_retrieval: LODPropertiesRetrieval = None):
         if field_config_dict is None:
             field_config_dict = {}
 
@@ -143,8 +145,15 @@ class ContentAnalyzerConfig:
         self.__field_config_dict: Dict[str, FieldConfig] = field_config_dict
         self.__source: RawInformationSource = source
         self.__id_field_name: str = id_field_name
+        self.__lod_properties_retrieval: LODPropertiesRetrieval = lod_properties_retrieval
 
         FieldRepresentationPipeline.instance_counter = 0
+
+    def set_lod_properties_retrieval(self, lod_properties_retrieval: LODPropertiesRetrieval):
+        self.__lod_properties_retrieval = lod_properties_retrieval
+
+    def get_lod_properties_retrieval(self):
+        return self.__lod_properties_retrieval
 
     def get_search_index(self):
         return self.__search_index

--- a/orange_cb_recsys/content_analyzer/config.yml
+++ b/orange_cb_recsys/content_analyzer/config.yml
@@ -5,8 +5,12 @@
   source_type: "json"
   id_field_name:
   - "imdbID"
-  start_from: '0'
-  end_up_at: "all"
+  get_lod_properties:
+    class: 'dbpedia_mapping'
+    mode: 'only_retrieved_evaluated'
+    entity_type: 'Film'
+    lang: 'EN'
+    label_field: 'Title'
   fields:
   - field_name: "Title"
     memory_interface: "index"

--- a/orange_cb_recsys/content_analyzer/content_analyzer_main.py
+++ b/orange_cb_recsys/content_analyzer/content_analyzer_main.py
@@ -262,6 +262,10 @@ class ContentsProducer:
         content_id = id_merger(raw_content, self.__config.get_id_field_name())
         content = Content(content_id)
 
+        if self.__config.get_lod_properties_retrieval() is not None:
+            lod_properties = self.__config.get_lod_properties_retrieval().get_properties(raw_content)
+            content.set_lod_properties(lod_properties)
+
         if self.__indexer is not None:
             self.__indexer.new_content()
             self.__indexer.new_field(CONTENT_ID, content_id)

--- a/orange_cb_recsys/content_analyzer/content_representation/content.py
+++ b/orange_cb_recsys/content_analyzer/content_representation/content.py
@@ -19,7 +19,9 @@ class Content:
         and their name as dictionary key
     """
     def __init__(self, content_id: str,
-                 field_dict: Dict[str, ContentField] = None):
+                 field_dict: Dict[str, ContentField] = None,
+                 lod_properties: Dict[str, str] = None):
+        self.__lod_properties = lod_properties
         if field_dict is None:
             field_dict = {}       # list o dict
         self.__index_document_id: int = None

--- a/orange_cb_recsys/content_analyzer/content_representation/content.py
+++ b/orange_cb_recsys/content_analyzer/content_representation/content.py
@@ -15,18 +15,26 @@ class Content:
     Args:
         content_id (str): identifier
         field_dict (dict[str, ContentField]): dictionary
-        containing the fields instances for the content,
-        and their name as dictionary key
+            containing the fields instances for the content,
+            and their name as dictionary key
+        lod_properties (Dict[str, str]): dictionary that contains
+            exogenous knowledge from a ontology via LOD cloud
     """
     def __init__(self, content_id: str,
                  field_dict: Dict[str, ContentField] = None,
                  lod_properties: Dict[str, str] = None):
-        self.__lod_properties = lod_properties
+        self.__lod_properties: Dict[str, str] = lod_properties
         if field_dict is None:
             field_dict = {}       # list o dict
         self.__index_document_id: int = None
         self.__content_id: str = content_id
         self.__field_dict: Dict[str, ContentField] = field_dict
+
+    def set_lod_properties(self, lod_properties: Dict[str, str]):
+        self.__lod_properties = lod_properties
+
+    def get_lod_properties(self):
+        return self.__lod_properties
 
     def set_index_document_id(self, index_document_id: int):
         self.__index_document_id = index_document_id

--- a/orange_cb_recsys/content_analyzer/lod_properties_retrieval.py
+++ b/orange_cb_recsys/content_analyzer/lod_properties_retrieval.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Dict
 
 
 class LODPropertiesRetrieval(ABC):
@@ -6,6 +7,174 @@ class LODPropertiesRetrieval(ABC):
         pass
 
     @abstractmethod
-    def retrieve(self):
+    def retrieve(self) -> Dict[str, str]:
         pass
 
+
+class DBPediaMappingTechnique(LODPropertiesRetrieval):
+    """
+    Class that creates a list of couples like this:
+        <property: property value URI>
+    """
+
+    def __init__(self, entity_type: str, lang: str, label_field: str, additional_filters=None):
+        super().__init__()
+
+        if additional_filters is None:
+            additional_filters = {}
+
+        self.__additional_filters = additional_filters
+        self.__entity_type = entity_type
+        self.__lang = lang
+        self.__label_field = label_field
+
+        self.__sparql = SPARQLWrapper("http://dbpedia.org/sparql")
+        self.__sparql.setReturnFormat(JSON)
+
+        self.__has_label = self.__check_has_label()
+
+    def set_label_field(self, label_field: str):
+        self.__label_field = label_field
+
+    def __check_has_label(self):
+        query = "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> PREFIX dbo: <http://dbpedia.org/ontology/>  "
+        query += "SELECT DISTINCT "
+
+        query += ', '.join("?%s" % field_name.lower() for field_name in self.__additional_filters)
+
+        query += " WHERE { "
+
+        query += '. '.join(
+            ["?uri dbo:" + property_name + ' ?' + field_name.lower() + "_tmp" for field_name, property_name in
+             self.__additional_filters.items()]) + '. '
+
+        query += ' '.join(
+            ["OPTIONAL { ?" + field_name.lower() + "_tmp" + " rdfs:label" ' ?' + field_name.lower() + " }" for
+             field_name, property_name in
+             self.__additional_filters.items()])
+
+        query += " } LIMIT 1 OFFSET 0"
+
+        self.__sparql.setQuery(query)
+        results = self.__sparql.query().convert()
+
+        result = results["results"]["bindings"][0]
+
+        return result.keys()
+
+    def __mapping_query(self, raw_content):
+        query = "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> PREFIX dbo: <http://dbpedia.org/ontology/>  "
+        query += "SELECT DISTINCT ?uri  "
+
+        query += "WHERE { "
+
+        # type matching
+        query += "?uri rdf:type dbo:%s . " % self.__entity_type
+
+        # label matching
+        query += "?uri rdfs:label " + '?' + self.__label_field.lower() + '. '
+
+        # filter fields assignments
+        query += '. '.join(["?uri dbo:%s ?%s. " % (property_name, field_name.lower()) +
+                            "FILTER (" +
+                            ' || '.join(["regex(?%s" % field_name.lower() +
+                                         ("_label" if field_name.lower() in self.__has_label else '') +
+                                         ', \"' + clean_no_unders(value) + '\", "i")'
+                                         for value in (raw_content[field_name].split(', '))]) +
+                            ")" for field_name, property_name in
+                            self.__additional_filters.items()])
+
+        if len(self.__has_label) != 0:
+            query += '. '
+
+        # label retrieval for fields with label
+        query += '. '.join(
+            ["?%s rdfs:label ?%s_label" % (field_name.lower(), field_name.lower())
+             for field_name in self.__has_label])
+
+        # lang filter
+        query += ". FILTER langMatches(lang(?%s), \"%s\"). " % (self.__label_field.lower(), self.__lang)
+
+        # label filter
+        query += "FILTER regex(?%s, \"%s\", \"i\"). " % (self.__label_field.lower(), clean_no_unders(raw_content[self.__label_field]))
+
+        query += " } "
+
+        self.__sparql.setQuery(query)
+        results = self.__sparql.query().convert()
+
+        if len(results["results"]["bindings"]) == 0:
+            raise ValueError("No mapping found")
+
+        result = results["results"]["bindings"][0]
+        uri = result["uri"]["value"]
+        return uri
+
+    def __get_properties_query(self):
+        query = "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> PREFIX dbo: <http://dbpedia.org/ontology/>  "
+        query += "SELECT DISTINCT ?property_label WHERE { "
+        query += "{ "
+        query += "?property rdfs:domain ?class. "
+        query += "dbo:%s rdfs:subClassOf+ ?class. " % self.__entity_type
+        query += "} UNION {"
+        query += "?property rdfs:domain dbo:%s" % self.__entity_type
+        query += "} "
+        query += "?property rdfs:label ?property_label. "
+        query += "FILTER (langMatches(lang(?property_label), \"EN\")). }"
+
+        self.__sparql.setQuery(query)
+        results = self.__sparql.query().convert()
+
+        if len(results["results"]["bindings"]) == 0:
+            return None
+        property_labels = [clean_with_unders(row["property_label"]["value"])
+                           for row in results["results"]["bindings"]]
+
+        return property_labels
+
+    def __retrieve_property_values(self, uri, new_property_labels):
+        if uri is None:
+            return None
+        query = "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> "
+        query += "SELECT ?p ?o WHERE { <%s> ?p_tmp ?o. ?p_tmp rdfs:label ?p }" % uri
+
+        self.__sparql.setQuery(query)
+        results = self.__sparql.query().convert()
+
+        result_dict = {}
+        for row in results["results"]["bindings"]:
+            property_label = clean_with_unders(row["p"]["value"])
+
+            if property_label in new_property_labels:
+                result_dict[property_label] = row["o"]["value"]
+
+        return result_dict
+
+    def produce_content(self, name, raw_content):
+        new_property_labels = self.__get_properties_query()
+        original_property_labels = []
+
+        for key in raw_content.keys():
+            original_property_labels.append(key)
+
+        properties = {}
+
+        try:
+            uri = self.__mapping_query(raw_content)
+            result_dict = self.__retrieve_property_values(uri, new_property_labels)
+        except ValueError:
+            result_dict = {}
+
+        for property_label in new_property_labels:
+            if property_label in result_dict.keys():
+                properties[property_label] = result_dict[property_label]
+            else:
+                properties[property_label] = ""
+
+        for property_label in original_property_labels:
+            if property_label in raw_content.keys():
+                properties[property_label] = raw_content[property_label]
+            else:
+                properties[property_label] = ""
+
+        print(properties)

--- a/orange_cb_recsys/content_analyzer/lod_properties_retrieval.py
+++ b/orange_cb_recsys/content_analyzer/lod_properties_retrieval.py
@@ -1,5 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Dict
+import pandas as pd
+from SPARQLWrapper import SPARQLWrapper, JSON
+from orange_cb_recsys.utils.string_cleaner import clean_with_unders, clean_no_unders
 
 
 class LODPropertiesRetrieval(ABC):

--- a/orange_cb_recsys/content_analyzer/lod_properties_retrieval.py
+++ b/orange_cb_recsys/content_analyzer/lod_properties_retrieval.py
@@ -6,11 +6,31 @@ from orange_cb_recsys.utils.string_cleaner import clean_with_unders, clean_no_un
 
 
 class LODPropertiesRetrieval(ABC):
-    def __init__(self):
-        pass
+
+    def __init__(self, mode: str = 'only_retrieved_evaluated'):
+        self.__mode = self.__check_mode(mode)
+
+    @staticmethod
+    def __check_mode(mode):
+        modalities = [
+            'all',
+            'all_retrieved',
+            'only_retrieved_evaluated',
+            'original_retrieved',
+        ]
+        if mode in modalities:
+            return mode
+        else:
+            return 'all'
+
+    def set_mode(self, mode):
+        self.__mode = self.__check_mode(mode)
+
+    def get_mode(self):
+        return self.__mode
 
     @abstractmethod
-    def retrieve(self) -> Dict[str, str]:
+    def get_properties(self, raw_content: Dict[str, object]) -> Dict[str, str]:
         pass
 
 
@@ -20,8 +40,9 @@ class DBPediaMappingTechnique(LODPropertiesRetrieval):
         <property: property value URI>
     """
 
-    def __init__(self, entity_type: str, lang: str, label_field: str, additional_filters=None):
-        super().__init__()
+    def __init__(self, entity_type: str, lang: str, label_field: str, additional_filters=None,
+                 mode: str = 'only_retrieved_evaluated'):
+        super().__init__(mode)
 
         if additional_filters is None:
             additional_filters = {}
@@ -40,30 +61,33 @@ class DBPediaMappingTechnique(LODPropertiesRetrieval):
         self.__label_field = label_field
 
     def __check_has_label(self):
-        query = "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> PREFIX dbo: <http://dbpedia.org/ontology/>  "
-        query += "SELECT DISTINCT "
+        if len(self.__additional_filters) > 0:
+            query = "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> PREFIX dbo: <http://dbpedia.org/ontology/>  "
+            query += "SELECT DISTINCT "
 
-        query += ', '.join("?%s" % field_name.lower() for field_name in self.__additional_filters)
+            query += ', '.join("?%s" % field_name.lower() for field_name in self.__additional_filters)
 
-        query += " WHERE { "
+            query += " WHERE { "
 
-        query += '. '.join(
-            ["?uri dbo:" + property_name + ' ?' + field_name.lower() + "_tmp" for field_name, property_name in
-             self.__additional_filters.items()]) + '. '
+            query += '. '.join(
+                ["?uri dbo:" + property_name + ' ?' + field_name.lower() + "_tmp" for field_name, property_name in
+                 self.__additional_filters.items()]) + '. '
 
-        query += ' '.join(
-            ["OPTIONAL { ?" + field_name.lower() + "_tmp" + " rdfs:label" ' ?' + field_name.lower() + " }" for
-             field_name, property_name in
-             self.__additional_filters.items()])
+            query += ' '.join(
+                ["OPTIONAL { ?" + field_name.lower() + "_tmp" + " rdfs:label" ' ?' + field_name.lower() + " }" for
+                 field_name, property_name in
+                 self.__additional_filters.items()])
 
-        query += " } LIMIT 1 OFFSET 0"
+            query += " } LIMIT 1 OFFSET 0"
 
-        self.__sparql.setQuery(query)
-        results = self.__sparql.query().convert()
+            self.__sparql.setQuery(query)
+            results = self.__sparql.query().convert()
 
-        result = results["results"]["bindings"][0]
+            result = results["results"]["bindings"][0]
 
-        return result.keys()
+            return result.keys()
+        else:
+            return []
 
     def __mapping_query(self, raw_content):
         query = "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> PREFIX dbo: <http://dbpedia.org/ontology/>  "
@@ -75,7 +99,10 @@ class DBPediaMappingTechnique(LODPropertiesRetrieval):
         query += "?uri rdf:type dbo:%s . " % self.__entity_type
 
         # label matching
-        query += "?uri rdfs:label " + '?' + self.__label_field.lower() + '. '
+        query += "?uri rdfs:label " + '?' + self.__label_field.lower()
+
+        if (len(self.__additional_filters)) > 0:
+            query += '. '
 
         # filter fields assignments
         query += '. '.join(["?uri dbo:%s ?%s. " % (property_name, field_name.lower()) +
@@ -99,7 +126,8 @@ class DBPediaMappingTechnique(LODPropertiesRetrieval):
         query += ". FILTER langMatches(lang(?%s), \"%s\"). " % (self.__label_field.lower(), self.__lang)
 
         # label filter
-        query += "FILTER regex(?%s, \"%s\", \"i\"). " % (self.__label_field.lower(), clean_no_unders(raw_content[self.__label_field]))
+        query += "FILTER regex(?%s, \"%s\", \"i\"). " % (
+            self.__label_field.lower(), clean_no_unders(raw_content[self.__label_field]))
 
         query += " } "
 
@@ -153,31 +181,97 @@ class DBPediaMappingTechnique(LODPropertiesRetrieval):
 
         return result_dict
 
-    def produce_content(self, name, raw_content):
+    def __get_only_retrieved_evaluated(self, raw_content: Dict[str, object]) -> Dict[str, str]:
         new_property_labels = self.__get_properties_query()
-        original_property_labels = []
-
-        for key in raw_content.keys():
-            original_property_labels.append(key)
-
-        properties = {}
-
         try:
             uri = self.__mapping_query(raw_content)
             result_dict = self.__retrieve_property_values(uri, new_property_labels)
         except ValueError:
             result_dict = {}
+        return result_dict
 
+    def __get_all_properties_retrieved(self, raw_content: Dict[str, object]) -> Dict[str, str]:
+        new_property_labels = self.__get_properties_query()
+        result_dict = self.__get_only_retrieved_evaluated(raw_content)
+        properties = {}
         for property_label in new_property_labels:
             if property_label in result_dict.keys():
                 properties[property_label] = result_dict[property_label]
             else:
                 properties[property_label] = ""
+        return properties
+
+    def __get_original_retrieved(self, raw_content: Dict[str, object]) -> Dict[str, str]:
+        original_property_labels = []
+        original_properties = {}
+        for key in raw_content.keys():
+            original_property_labels.append(key)
+
+        retrieved_properties = self.__get_only_retrieved_evaluated(raw_content)
 
         for property_label in original_property_labels:
-            if property_label in raw_content.keys():
+            if property_label in retrieved_properties.keys():
+                original_properties[property_label] = retrieved_properties[property_label]
+            else:
+                original_properties[property_label] = ""
+
+        return original_properties
+
+    def __get_all_properties(self, raw_content: Dict[str, object]) -> Dict[str, str]:
+        all_prop_retrieved = self.__get_all_properties_retrieved(raw_content)
+        property_labels = self.__get_properties_query()
+        properties = {}
+        for key in raw_content.keys():
+            property_labels.append(key)
+
+        for property_label in property_labels:
+            if property_label in all_prop_retrieved.keys() and all_prop_retrieved[property_label] != '':
+                properties[property_label] = all_prop_retrieved[property_label]
+            elif property_label in raw_content.keys():
                 properties[property_label] = raw_content[property_label]
             else:
                 properties[property_label] = ""
+        return properties
 
-        print(properties)
+    def get_properties(self, raw_content: Dict[str, object]) -> Dict[str, str]:
+        if self.get_mode() == 'only_retrieved_evaluated':
+            return self.__get_only_retrieved_evaluated(raw_content)
+
+        if self.get_mode() == 'all_retrieved':
+            return self.__get_all_properties_retrieved(raw_content)
+
+        if self.get_mode() == 'original_retrieved':
+            return self.__get_original_retrieved(raw_content)
+
+        if self.get_mode() == 'all':
+            return self.__get_all_properties(raw_content)
+
+
+raw_content = {"Title": "Jumanji", "Year": "1995", "Rated": "PG", "Released": "15 Dec 1995", "Runtime": "104 min",
+               "Genre": "Adventure, Family, Fantasy", "Director": "Joe Johnston",
+               "Writer": "Jonathan Hensleigh (screenplay by), Greg Taylor (screenplay by), Jim Strain (screenplay by), Greg Taylor (screen story by), Jim Strain (screen story by), Chris Van Allsburg (screen story by), Chris Van Allsburg (based on the book by)",
+               "Actors": "Robin Williams, Jonathan Hyde, Kirsten Dunst, Bradley Pierce",
+               "Plot": "After being trapped in a jungle board game for 26 years, a Man-Child wins his release from the game. But, no sooner has he arrived that he is forced to play again, and this time sets the creatures of the jungle loose on the city. Now it is up to him to stop them.",
+               "Language": "English, French", "Country": "USA", "Awards": "4 wins & 9 nominations.",
+               "Poster": "https://m.media-amazon.com/images/M/MV5BZTk2ZmUwYmEtNTcwZS00YmMyLWFkYjMtNTRmZDA3YWExMjc2XkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_SX300.jpg",
+               "Ratings": [{"Source": "Internet Movie Database", "Value": "6.9/10"},
+                           {"Source": "Rotten Tomatoes", "Value": "53%"}, {"Source": "Metacritic", "Value": "39/100"}],
+               "Metascore": "39", "imdbRating": "6.9", "imdbVotes": "260,909", "imdbID": "tt0113497", "Type": "movie",
+               "DVD": "25 Jan 2000", "BoxOffice": "N/A", "Production": "Sony Pictures Home Entertainment",
+               "Website": "N/A", "Response": "True"}
+
+mapp = DBPediaMappingTechnique('Film', 'EN', 'Title')
+prop = mapp.get_properties(raw_content)
+print(prop)
+
+"""mapp.set_mode('all')
+prop = mapp.get_properties(raw_content)
+print(prop)
+
+mapp.set_mode('all_retrieved')
+prop = mapp.get_properties(raw_content)
+print(prop)
+
+mapp.set_mode('original_retrieved')
+prop = mapp.get_properties(raw_content)
+print(prop)"""

--- a/orange_cb_recsys/content_analyzer/lod_properties_retrieval.py
+++ b/orange_cb_recsys/content_analyzer/lod_properties_retrieval.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+
+
+class LODPropertiesRetrieval(ABC):
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def retrieve(self):
+        pass
+

--- a/orange_cb_recsys/content_analyzer/lod_properties_retrieval.py
+++ b/orange_cb_recsys/content_analyzer/lod_properties_retrieval.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod
 from typing import Dict
 import pandas as pd
 from SPARQLWrapper import SPARQLWrapper, JSON
+
+from orange_cb_recsys.utils.const import logger
 from orange_cb_recsys.utils.string_cleaner import clean_with_unders, clean_no_unders
 
 
@@ -234,6 +236,7 @@ class DBPediaMappingTechnique(LODPropertiesRetrieval):
         return properties
 
     def get_properties(self, raw_content: Dict[str, object]) -> Dict[str, str]:
+        logger.info("Extracting LOD properties")
         if self.get_mode() == 'only_retrieved_evaluated':
             return self.__get_only_retrieved_evaluated(raw_content)
 
@@ -245,33 +248,3 @@ class DBPediaMappingTechnique(LODPropertiesRetrieval):
 
         if self.get_mode() == 'all':
             return self.__get_all_properties(raw_content)
-
-
-raw_content = {"Title": "Jumanji", "Year": "1995", "Rated": "PG", "Released": "15 Dec 1995", "Runtime": "104 min",
-               "Genre": "Adventure, Family, Fantasy", "Director": "Joe Johnston",
-               "Writer": "Jonathan Hensleigh (screenplay by), Greg Taylor (screenplay by), Jim Strain (screenplay by), Greg Taylor (screen story by), Jim Strain (screen story by), Chris Van Allsburg (screen story by), Chris Van Allsburg (based on the book by)",
-               "Actors": "Robin Williams, Jonathan Hyde, Kirsten Dunst, Bradley Pierce",
-               "Plot": "After being trapped in a jungle board game for 26 years, a Man-Child wins his release from the game. But, no sooner has he arrived that he is forced to play again, and this time sets the creatures of the jungle loose on the city. Now it is up to him to stop them.",
-               "Language": "English, French", "Country": "USA", "Awards": "4 wins & 9 nominations.",
-               "Poster": "https://m.media-amazon.com/images/M/MV5BZTk2ZmUwYmEtNTcwZS00YmMyLWFkYjMtNTRmZDA3YWExMjc2XkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_SX300.jpg",
-               "Ratings": [{"Source": "Internet Movie Database", "Value": "6.9/10"},
-                           {"Source": "Rotten Tomatoes", "Value": "53%"}, {"Source": "Metacritic", "Value": "39/100"}],
-               "Metascore": "39", "imdbRating": "6.9", "imdbVotes": "260,909", "imdbID": "tt0113497", "Type": "movie",
-               "DVD": "25 Jan 2000", "BoxOffice": "N/A", "Production": "Sony Pictures Home Entertainment",
-               "Website": "N/A", "Response": "True"}
-
-mapp = DBPediaMappingTechnique('Film', 'EN', 'Title')
-prop = mapp.get_properties(raw_content)
-print(prop)
-
-"""mapp.set_mode('all')
-prop = mapp.get_properties(raw_content)
-print(prop)
-
-mapp.set_mode('all_retrieved')
-prop = mapp.get_properties(raw_content)
-print(prop)
-
-mapp.set_mode('original_retrieved')
-prop = mapp.get_properties(raw_content)
-print(prop)"""

--- a/orange_cb_recsys/content_analyzer/run.py
+++ b/orange_cb_recsys/content_analyzer/run.py
@@ -130,8 +130,9 @@ def content_config_run(config_list: List[Dict]):
             search_index)
 
         if 'get_lod_properties' in content_config.keys():
-            lod_prop = dict_detector(content_config['get_lod_properties'])
-            content_analyzer_config.set_lod_properties_retrieval(lod_prop)
+            class_name = content_config['get_lod_properties'].pop('class')
+            args = dict_detector(content_config['get_lod_properties'])
+            content_analyzer_config.set_lod_properties_retrieval(runnable_instances[class_name](**args))
 
         for field_dict in content_config['fields']:
             try:

--- a/orange_cb_recsys/content_analyzer/run.py
+++ b/orange_cb_recsys/content_analyzer/run.py
@@ -18,6 +18,7 @@ from orange_cb_recsys.content_analyzer.field_content_production_techniques. \
 from orange_cb_recsys.content_analyzer.field_content_production_techniques. \
     tf_idf import LuceneTfIdf, SkLearnTfIdf
 from orange_cb_recsys.content_analyzer.information_processor.nlp import NLTK
+from orange_cb_recsys.content_analyzer.lod_properties_retrieval import DBPediaMappingTechnique
 from orange_cb_recsys.content_analyzer.memory_interfaces.text_interface import IndexInterface
 from orange_cb_recsys.content_analyzer.ratings_manager.rating_processor import NumberNormalizer
 from orange_cb_recsys.content_analyzer.ratings_manager.ratings_importer import \
@@ -65,7 +66,8 @@ runnable_instances = {
     "text_blob_sentiment": TextBlobSentimentAnalysis,
     "number_normalizer": NumberNormalizer,
     "search_index": SearchIndexing,
-    "sk_learn_tf-idf": SkLearnTfIdf
+    "sk_learn_tf-idf": SkLearnTfIdf,
+    "dbpedia_mapping": DBPediaMappingTechnique
 }
 
 
@@ -107,6 +109,7 @@ def dict_detector(technique_dict):
         if isinstance(value, dict) and 'class' in value.keys():
             parameter_class_name = value.pop('class')
             technique_dict[key] = runnable_instances[parameter_class_name](**value)
+            break
 
     return technique_dict
 
@@ -117,6 +120,7 @@ def content_config_run(config_list: List[Dict]):
         search_index = False
         if 'search_index' in content_config.keys():
             search_index = content_config['search_index']
+
         content_analyzer_config = ContentAnalyzerConfig(
             content_config["content_type"],
             runnable_instances[content_config['source_type']]
@@ -124,6 +128,10 @@ def content_config_run(config_list: List[Dict]):
             content_config['id_field_name'],
             content_config['output_directory'],
             search_index)
+
+        if 'get_lod_properties' in content_config.keys():
+            lod_prop = dict_detector(content_config['get_lod_properties'])
+            content_analyzer_config.set_lod_properties_retrieval(lod_prop)
 
         for field_dict in content_config['fields']:
             try:

--- a/orange_cb_recsys/utils/string_cleaner.py
+++ b/orange_cb_recsys/utils/string_cleaner.py
@@ -1,0 +1,26 @@
+import re
+
+
+def clean_with_unders(text: str):
+    """
+    Deletes . ? - $ ( ) symbols and replaces spaces with under_scores from the text
+    Args:
+        text (str): string
+
+    Returns:
+        string without described symbols
+    """
+    return text.replace(' ', '_').replace('(', '').replace(')', '').\
+        replace('$', '').replace('-', '').replace('.', '').replace('?', '')
+
+
+def clean_no_unders(text: str):
+    """
+    Returns a clean string without punctuation and under_scores
+    Args:
+        text (str): string
+
+    Returns:
+        string without described symbols
+    """
+    return re.sub(r"[^a-zA-Z0-9]+", ' ', text)

--- a/test/content_analyzer/test_lod_properties_retrieval.py
+++ b/test/content_analyzer/test_lod_properties_retrieval.py
@@ -5,11 +5,18 @@ from orange_cb_recsys.content_analyzer.lod_properties_retrieval import DBPediaMa
 
 class TestDBPediaMappingTechnique(TestCase):
     def test_get_properties(self):
-        raw_content = {"Title": "Jumanji", "Year": "1995", "Rated": "PG", "Released": "15 Dec 1995", "Runtime": "104 min",
+        raw_content = {"Title": "Jumanji", "Year": "1995", "Rated": "PG", "Released": "15 Dec 1995",
+                       "Runtime": "104 min",
                        "Genre": "Adventure, Family, Fantasy", "Director": "Joe Johnston",
-                       "Writer": "Jonathan Hensleigh (screenplay by), Greg Taylor (screenplay by), Jim Strain (screenplay by), Greg Taylor (screen story by), Jim Strain (screen story by), Chris Van Allsburg (screen story by), Chris Van Allsburg (based on the book by)",
+                       "Writer": "Jonathan Hensleigh (screenplay by), Greg Taylor (screenplay by), "
+                                 "Jim Strain (screenplay by), Greg Taylor (screen story by), Jim Strain ("
+                                 "screen story by), Chris Van Allsburg (screen story by), "
+                                 "Chris Van Allsburg (based on the book by)",
                        "Actors": "Robin Williams, Jonathan Hyde, Kirsten Dunst, Bradley Pierce",
-                       "Plot": "After being trapped in a jungle board game for 26 years, a Man-Child wins his release from the game. But, no sooner has he arrived that he is forced to play again, and this time sets the creatures of the jungle loose on the city. Now it is up to him to stop them.",
+                       "Plot": "After being trapped in a jungle board game for 26 years, "
+                               "a Man-Child wins his release from the game. But, no sooner has he arrived that he "
+                               "is forced to play again, and this time sets the creatures of "
+                               "the jungle loose on the city. Now it is up to him to stop them.",
                        "Language": "English, French", "Country": "USA", "Awards": "4 wins & 9 nominations.",
                        "Poster": "https://m.media-amazon.com/images/M/MV5BZTk2ZmUwYmEtNTcwZS00YmMyLWFkYjMtNTRmZDA3YWExMjc2XkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_SX300.jpg",
                        "Ratings": [{"Source": "Internet Movie Database", "Value": "6.9/10"},

--- a/test/content_analyzer/test_lod_properties_retrieval.py
+++ b/test/content_analyzer/test_lod_properties_retrieval.py
@@ -1,0 +1,40 @@
+from unittest import TestCase
+
+from orange_cb_recsys.content_analyzer.lod_properties_retrieval import DBPediaMappingTechnique
+
+
+class TestDBPediaMappingTechnique(TestCase):
+    def test_get_properties(self):
+        raw_content = {"Title": "Jumanji", "Year": "1995", "Rated": "PG", "Released": "15 Dec 1995", "Runtime": "104 min",
+                       "Genre": "Adventure, Family, Fantasy", "Director": "Joe Johnston",
+                       "Writer": "Jonathan Hensleigh (screenplay by), Greg Taylor (screenplay by), Jim Strain (screenplay by), Greg Taylor (screen story by), Jim Strain (screen story by), Chris Van Allsburg (screen story by), Chris Van Allsburg (based on the book by)",
+                       "Actors": "Robin Williams, Jonathan Hyde, Kirsten Dunst, Bradley Pierce",
+                       "Plot": "After being trapped in a jungle board game for 26 years, a Man-Child wins his release from the game. But, no sooner has he arrived that he is forced to play again, and this time sets the creatures of the jungle loose on the city. Now it is up to him to stop them.",
+                       "Language": "English, French", "Country": "USA", "Awards": "4 wins & 9 nominations.",
+                       "Poster": "https://m.media-amazon.com/images/M/MV5BZTk2ZmUwYmEtNTcwZS00YmMyLWFkYjMtNTRmZDA3YWExMjc2XkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_SX300.jpg",
+                       "Ratings": [{"Source": "Internet Movie Database", "Value": "6.9/10"},
+                                   {"Source": "Rotten Tomatoes", "Value": "53%"}, {"Source": "Metacritic", "Value": "39/100"}],
+                       "Metascore": "39", "imdbRating": "6.9", "imdbVotes": "260,909", "imdbID": "tt0113497", "Type": "movie",
+                       "DVD": "25 Jan 2000", "BoxOffice": "N/A", "Production": "Sony Pictures Home Entertainment",
+                       "Website": "N/A", "Response": "True"}
+
+        mapp = DBPediaMappingTechnique('Film', 'EN', 'Title')
+        prop = mapp.get_properties(raw_content)
+        print(prop)
+
+        mapp.set_mode('all')
+        prop = mapp.get_properties(raw_content)
+        print(prop)
+
+        mapp.set_mode('all_retrieved')
+        prop = mapp.get_properties(raw_content)
+        print(prop)
+
+        mapp.set_mode('original_retrieved')
+        prop = mapp.get_properties(raw_content)
+        print(prop)
+
+        mapp.set_label_field('Genre')
+        mapp.set_mode('only_retrieved_evaluated')
+        prop = mapp.get_properties(raw_content)
+        print(prop)

--- a/test/content_analyzer/test_run.py
+++ b/test/content_analyzer/test_run.py
@@ -34,6 +34,13 @@ content_config_dict_ = {
     "raw_source_path": "datasets/movies_info_reduced.json",
     "source_type": "json",
     "id_field_name": ["imdbID"],
+    "get_lod_properties": {
+        "class": "dbpedia_mapping",
+        "mode": 'only_retrieved_evaluated',
+        "entity_type": 'Film',
+        "lang": 'EN',
+        "label_field": 'Title'
+    },
     "fields": [{
         "field_name": "Title",
         "memory_interface": "None",


### PR DESCRIPTION
In questa pr ho Creato la classe astratta `LODPropertiesRetrieval` che viene ereditata da `DBPediaMappingTechnique`

L'utente può scegliere se:
1. estrarre solo le proprietà LOD che hanno un valore (URI o Literal)
2. estrarre tutte le proprietà LOD, anche quelle che per quell'istanza non hanno valore
3. combinare il dizionario di proprietà originali (dal dataset) e le proprietà del punto 2
4. ottenere l'intersezione dei dizionari, con i valori LOD

Ho aggiornato il content analyzer, il config e il run.
L'estrazione delle proprietà avviene in `ContentProducer`, nel metodo produce_content, prima di eseguire le operazioni riguardanti i field selezionati

nel config.yml la sintassi sarebbe la seguente
![Screenshot from 2020-06-19 18-12-59](https://user-images.githubusercontent.com/45966780/85155131-ac8cdb80-b258-11ea-9047-a32b9d13e206.png)


closes #78 